### PR TITLE
Fix #5

### DIFF
--- a/src/main/java/asatsuki256/germplasm/core/machine/ContainerResearchDesk.java
+++ b/src/main/java/asatsuki256/germplasm/core/machine/ContainerResearchDesk.java
@@ -19,7 +19,7 @@ public class ContainerResearchDesk extends Container {
         this.zCoord = z;
         this.inventory = tile;
         
-        this.addSlotToContainer(new Slot(tile, 0, 80, 103));
+        this.addSlotToContainer(new SlotInventoryValid(tile, 0, 80, 103));
         
         int i = 34;
         

--- a/src/main/java/asatsuki256/germplasm/core/machine/SlotInventoryValid.java
+++ b/src/main/java/asatsuki256/germplasm/core/machine/SlotInventoryValid.java
@@ -1,0 +1,19 @@
+package asatsuki256.germplasm.core.machine;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class SlotInventoryValid extends Slot {
+
+	public SlotInventoryValid(IInventory inventoryIn, int index, int xPosition, int yPosition) {
+		super(inventoryIn, index, xPosition, yPosition);
+	}
+	
+	@Override
+	public boolean isItemValid(ItemStack stack)
+    {
+        return this.inventory.isItemValidForSlot(this.getSlotIndex(), stack);
+    }
+
+}

--- a/src/main/java/asatsuki256/germplasm/core/network/MHandlerResearchDeskServer.java
+++ b/src/main/java/asatsuki256/germplasm/core/network/MHandlerResearchDeskServer.java
@@ -26,6 +26,7 @@ public class MHandlerResearchDeskServer implements IMessageHandler<MessageResear
 			ItemStack seedStack = ((TileResearchDesk)tile).getStackInSlot(0);
 			NBTTagCompound nbt = seedStack.getTagCompound();
 			IGermplasmUnitBase unit = GeneAPI.nbtHelper.getUnitFromIndividualNBT(nbt);
+			if (unit == null) return null;
 			if(message.type == MessageResearchDeskServer.TYPE_NAME) {
 				String name = message.name;
 				if(name == null || name.isEmpty()) {

--- a/src/main/java/asatsuki256/germplasm/core/tileentity/TileResearchDesk.java
+++ b/src/main/java/asatsuki256/germplasm/core/tileentity/TileResearchDesk.java
@@ -3,6 +3,8 @@ package asatsuki256.germplasm.core.tileentity;
 import static asatsuki256.germplasm.core.GermplasmCore.NBT_PREFIX;
 import static asatsuki256.germplasm.core.GermplasmCore.UNLOC_PREFIX;
 
+import asatsuki256.germplasm.api.gene.GeneAPI;
+import asatsuki256.germplasm.api.gene.unit.IGermplasmUnitBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -148,7 +150,9 @@ public class TileResearchDesk extends TileEntity implements IInventory {
 
 	@Override
 	public boolean isItemValidForSlot(int index, ItemStack stack) {
-		return true;
+		NBTTagCompound nbt = stack.getTagCompound();
+		IGermplasmUnitBase unit = GeneAPI.nbtHelper.getUnitFromIndividualNBT(nbt);
+		return unit != null;
 	}
 
 	@Override


### PR DESCRIPTION
Research Deskのメッセージにnullチェック追加
Research Deskのスロットに、命名可能な(Germplasm Unitをもつ)アイテムしか入らなくした